### PR TITLE
Fix "warning: no return statement in function returning non-void" compilation warning

### DIFF
--- a/yumi_hw/include/yumi_hw/yumi_gripper_node.h
+++ b/yumi_hw/include/yumi_hw/yumi_gripper_node.h
@@ -42,7 +42,7 @@ class YumiGripperStateHandler : public industrial::message_handler::MessageHandl
 		boost::mutex data_buffer_mutex;
 
     public:
-		bool getGripperStates(float &left, float &right) 
+		void getGripperStates(float &left, float &right) 
 		{ 
 			boost::mutex::scoped_lock lock(data_buffer_mutex);
 			left = gripper_positions[0];
@@ -170,7 +170,7 @@ class YumiGripperStateInterface {
 			connection_command->sendMsg(grasp_msg);
 		}
 
-		bool init(std::string ip = "", int port = DEFAULT_STATE_PORT, int port_command = DEFAULT_COMMAND_PORT) 
+		void init(std::string ip = "", int port = DEFAULT_STATE_PORT, int port_command = DEFAULT_COMMAND_PORT) 
 		{
 			/* Initialize connection */
 			char* ip_addr = strdup(ip.c_str());  // connection.init() requires "char*", not "const char*"

--- a/yumi_hw/src/grippers_hw.cpp
+++ b/yumi_hw/src/grippers_hw.cpp
@@ -48,7 +48,7 @@ class YumiGripperStateHandler : public industrial::message_handler::MessageHandl
 		boost::mutex data_buffer_mutex;
 
     public:
-		bool getGripperStates(float &left, float &right) 
+		void getGripperStates(float &left, float &right) 
 		{ 
 			boost::mutex::scoped_lock lock(data_buffer_mutex);
 			left = gripper_positions[0];


### PR DESCRIPTION
Just gets rid of a warning during compilation.
Unlikely this will get merged upstream due to inactivity in kth-ros-pkg/yumi.